### PR TITLE
Used fixed matching instead of regex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,8 @@
 # loggit 2.1.2
 
-This is a small patch release with the following changes:
-
-- Change write_ndjson` to use `base::message()` again instead of `cat()` for
-  when `echo = TRUE`, specifically for `knitr::knit_hooks()` support (h/t
-  @hlau_mdsol, see Github Issue #17).
-
-- Edit the preparser and default unsanitizer for `read_ndjson()` so colons are
-  also included as problematic tokens (h/t @sigbertklinke, Github Issue #18).
+This is a small patch release that changes `write_ndjson` to use
+`base::message()` again instead of `cat()` for when `echo = TRUE`, specifically
+for `knitr::knit_hooks()` support (h/t @hlau_mdsol, see Github Issue #17).
 
 # loggit 2.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # loggit 2.1.2
 
-This is a small patch release that changes `write_ndjson` to use
-`base::message()` again instead of `cat()` for when `echo = TRUE`, specifically
-for `knitr::knit_hooks()` support (h/t @hlau_mdsol, see Github Issue #17).
+- Changes `write_ndjson` to use`base::message()` again instead of `cat()` for when `echo = TRUE`, 
+  specifically for `knitr::knit_hooks()` support (h/t @hlau_mdsol, see Github Issue #17).
+- The loading of the log by `read_logs` is significantly accelerated and handles `:` correctly
 
 # loggit 2.1.1
 

--- a/R/json.R
+++ b/R/json.R
@@ -37,11 +37,10 @@ default_ndjson_sanitizer <- function(string, sanitize = TRUE) {
   map <- list(
     "\\{" = "__LEFTBRACE__",
     "\\}" = "__RIGHTBRACE__",
-    '"'   = "__DBLQUOTE__",
-    ","   = "__COMMA__",
-    "\r"  = "__CR__",
-    "\n"  = "__LF__",
-    ":"   = "__COLON__"
+    '"' = "__DBLQUOTE__",
+    "," = "__COMMA__",
+    "\r" = "__CR__",
+    "\n" = "__LF__"
   )
   
   for (k in names(map)) {
@@ -125,7 +124,7 @@ read_ndjson <- function(logfile, unsanitizer) {
   
   # Split out the log data into individual pieces, which will include JSON keys
   # AND values
-  log_kvs <- strsplit(logdata, '\\{|"|", |": |\\}')
+  log_kvs <- strsplit(logdata, '\\{|"|", |: |\\}')
   
   rowcount <- length(log_kvs)
   for (lognum in 1:rowcount) {

--- a/R/json.R
+++ b/R/json.R
@@ -122,15 +122,14 @@ read_ndjson <- function(logfile, unsanitizer) {
   # List first; easier to add to dynamically
   log_df <- list()
   
-  # Split out the log data into individual pieces, which will include JSON keys
-  # AND values
-  log_kvs <- strsplit(logdata, '\\{|"|", |: |\\}')
+  # Split out the log data into individual pieces, which will include JSON keys AND values
+  logdata <- substring(logdata, first = 3L, last = nchar(logdata) - 2L)
+  logdata <- strsplit(logdata, '", "', fixed = TRUE)
+  log_kvs <- lapply(logdata, FUN = function (x) unlist(strsplit(x, '": "', fixed = FALSE), use.names = FALSE))
   
   rowcount <- length(log_kvs)
   for (lognum in 1:rowcount) {
     rowdata <- log_kvs[[lognum]]
-    # Filter out emtpy values from strsplit()
-    rowdata <- rowdata[!(rowdata %in% c("", " "))]
     
     for (logfieldnum in 1:length(rowdata)) {
       # If odd, it's the key; if even, it's the value, where the preceding element

--- a/R/json.R
+++ b/R/json.R
@@ -35,8 +35,8 @@
 default_ndjson_sanitizer <- function(string, sanitize = TRUE) {
   # String map; will dispatch left-vs.-right replacement based on `sanitize` bool
   map <- list(
-    "\\{" = "__LEFTBRACE__",
-    "\\}" = "__RIGHTBRACE__",
+    "{" = "__LEFTBRACE__",
+    "}" = "__RIGHTBRACE__",
     '"' = "__DBLQUOTE__",
     "," = "__COMMA__",
     "\r" = "__CR__",
@@ -45,9 +45,9 @@ default_ndjson_sanitizer <- function(string, sanitize = TRUE) {
   
   for (k in names(map)) {
     if (sanitize) {
-      string <- gsub(k, map[k], string)
+      string <- gsub(k, map[k], string, fixed = TRUE)
     } else {
-      string <- gsub(map[k], k, string)
+      string <- gsub(map[k], k, string, fixed = TRUE)
     }
   }
   


### PR DESCRIPTION
Hello, I don't know which branch would be the right one for the PR, the develop seems suitable to me.

Closes #26. I saw that you already fixed it (in develop), but this way there is no need to escape the `:`.

```
# After reversing escaping ":"
> devtools::load_all()
> microbenchmark::microbenchmark(read_logs(), times = 10)
Unit: milliseconds
        expr     min       lq     mean  median       uq      max neval
 read_logs() 949.762 952.6262 974.7672 960.654 965.1672 1060.263    10

# After changing the sanatizer
> devtools::load_all()
> microbenchmark::microbenchmark(read_logs(), times = 10)
Unit: milliseconds
        expr      min       lq     mean   median       uq      max neval
 read_logs() 524.0726 527.1863 536.9793 528.3646 530.8387 596.9289    10

# Final version
> devtools::load_all()
> microbenchmark::microbenchmark(read_logs(), times = 10)
Unit: milliseconds
        expr      min       lq     mean   median       uq      max neval
 read_logs() 487.6132 492.4244 511.2865 496.9468 499.2765 584.3085    10
```

The times refer to loading 10,000 log entries